### PR TITLE
improve kwargs enforcement

### DIFF
--- a/src/hot_open/era5_helpers.py
+++ b/src/hot_open/era5_helpers.py
@@ -62,7 +62,7 @@ def _build_era5_df(response: object, fields: list[str]) -> pd.DataFrame:
     ).set_index("timestamp")
 
 
-def _era5_cache_path(lat: float, lon: float, start_date: str, end_date: str, fields: list[str]) -> Path:
+def _era5_cache_path(*, lat: float, lon: float, start_date: str, end_date: str, fields: list[str]) -> Path:
     """Build a deterministic parquet cache path from the request args."""
     args_blob = json.dumps(
         {"lat": lat, "lon": lon, "start_date": start_date, "end_date": end_date, "fields": list(fields)},
@@ -88,7 +88,7 @@ def get_era5_hourly_df(
     """
     if end_date is None:
         end_date = pd.Timestamp.now(tz="UTC").normalize().strftime("%Y-%m-%d")
-    cache_path = _era5_cache_path(lat, lon, start_date, end_date, fields)
+    cache_path = _era5_cache_path(lat=lat, lon=lon, start_date=start_date, end_date=end_date, fields=fields)
     if cache_path.exists():
         logger.info("Reading: %s", cache_path)
         return pd.read_parquet(cache_path)
@@ -122,6 +122,7 @@ def get_era5_hourly_df(
 
 
 def get_hot_era5_hourly_df(
+    *,
     start_date: str = HOT_ERA5_START,
     end_date: str = HOT_ERA5_END,
     fields: list[str] = HOT_ERA5_FIELDS,

--- a/src/hot_open/fastlog_helpers.py
+++ b/src/hot_open/fastlog_helpers.py
@@ -190,7 +190,11 @@ def _get_fl_resampled_one_device_one_day(  # noqa: PLR0913
         cache_path = (
             cache_dir / "fl_resampled" / park_id / device_id / f"{start_dt.strftime('%Y%m%d')}_{cache_key}.parquet"
         )
-        if cache_path.exists() and not refresh_cache:
+        if refresh_cache:
+            # Delete up-front so an empty recompute can't leave a stale parquet that later
+            # (non-refresh) runs would silently reuse, undermining the intent of refresh_cache.
+            cache_path.unlink(missing_ok=True)
+        elif cache_path.exists():
             source_mtime = _max_source_mtime(
                 park_id=park_id,
                 device_id=device_id,

--- a/src/hot_open/fastlog_helpers.py
+++ b/src/hot_open/fastlog_helpers.py
@@ -106,12 +106,17 @@ def get_fl_resampled(  # noqa: PLR0913
     cache_dir: Path | None = None,
     filestore_dir: Path | None = None,
     siemens_parks: set[str] | None = None,
+    refresh_cache: bool = False,
 ) -> pd.DataFrame:
     """Return resampled fastlog data for multiple devices as a multi-level (device_id, tag) DataFrame.
 
     ``siemens_parks`` overrides the set of park ids loaded with the Siemens fastlog reader;
     when ``None`` the module default ``SIEMENS_PARKS`` is used. Pass it to load parks that are
     not part of the public dataset.
+
+    The per-day cache self-invalidates when a day's source files are newer than its cached
+    parquet (e.g. late/backfilled data), so partial recent days recover on a later run. Pass
+    ``refresh_cache=True`` to force every day to be recomputed and overwritten regardless.
     """
     filestore_dir = get_filestore_dir() if filestore_dir is None else filestore_dir
     device_id_dfs: dict[str, pd.DataFrame] = {}
@@ -129,6 +134,7 @@ def get_fl_resampled(  # noqa: PLR0913
             min_data_count=min_data_count,
             cache_dir=cache_dir,
             siemens_parks=siemens_parks,
+            refresh_cache=refresh_cache,
         )
         if not device_id_df.index.is_monotonic_increasing:
             msg = f"Resampled data index for {device_id} is not monotonic increasing."
@@ -162,6 +168,7 @@ def _get_fl_resampled_one_device_one_day(  # noqa: PLR0913
     min_data_count: float | None = None,
     cache_dir: Path | None = None,
     siemens_parks: set[str] | None = None,
+    refresh_cache: bool = False,
 ) -> pd.DataFrame:
     if (end_dt_excl - start_dt) > dt.timedelta(days=1):
         msg = f"Date range must be one day or less. Got {start_dt=} {end_dt_excl=}"
@@ -172,18 +179,31 @@ def _get_fl_resampled_one_device_one_day(  # noqa: PLR0913
             msg = "Could not get current frame"
             raise RuntimeError(msg)
         args_info = inspect.getargvalues(frame)
+        # refresh_cache is a control flag, not a data parameter: exclude it so it overwrites the
+        # real cache file rather than writing to a different hash.
         params = {
             key: args_info.locals[key]
             for key in args_info.args
-            if key not in {"cache_dir", "filestore_dir", "siemens_parks"}
+            if key not in {"cache_dir", "filestore_dir", "siemens_parks", "refresh_cache"}
         }
         cache_key = create_consistent_hash(**params)
         cache_path = (
             cache_dir / "fl_resampled" / park_id / device_id / f"{start_dt.strftime('%Y%m%d')}_{cache_key}.parquet"
         )
-        if cache_path.exists():
-            logger.info("Reading: %s", cache_path)
-            return pd.read_parquet(cache_path)
+        if cache_path.exists() and not refresh_cache:
+            source_mtime = _max_source_mtime(
+                park_id=park_id,
+                device_id=device_id,
+                start_dt=start_dt,
+                end_dt_excl=end_dt_excl,
+                filestore_dir=filestore_dir,
+            )
+            # A freshly written parquet's mtime is later than every source file read to build it,
+            # so an unchanged day stays a hit; a backfilled day (newer source mtime) recomputes.
+            if source_mtime is None or cache_path.stat().st_mtime >= source_mtime:
+                logger.info("Reading: %s", cache_path)
+                return pd.read_parquet(cache_path)
+            logger.info("Cache stale (source newer than cache); recomputing: %s", cache_path)
     result_df = make_fl_resampled_one_device(
         park_id=park_id,
         device_id=device_id,
@@ -224,6 +244,35 @@ def _generate_dates_in_range(start_dt: dt.datetime, end_dt_excl: dt.datetime) ->
     return [date.date() for date in date_range]
 
 
+def _max_source_mtime(
+    *,
+    park_id: str,
+    device_id: str,
+    start_dt: dt.datetime,
+    end_dt_excl: dt.datetime,
+    filestore_dir: Path | None = None,
+) -> float | None:
+    """Return the newest mtime among the raw FL files feeding this day's resample, or None.
+
+    Mirrors ``make_fl_resampled_one_device``'s read window (``start_dt - 1 day`` to
+    ``end_dt_excl + 1 hour``) so a backfill into the neighbouring day folders also invalidates
+    the cache. ``None`` means no source files were found (treated as "cannot be stale").
+    """
+    filestore_dir = get_filestore_dir() if filestore_dir is None else filestore_dir
+    raw_start = start_dt - pd.Timedelta(days=1)
+    raw_end_excl = end_dt_excl + pd.Timedelta(hours=1)
+    mtimes: list[float] = []
+    for date in _generate_dates_in_range(raw_start, raw_end_excl):
+        day_dir = filestore_dir / "FL" / park_id / device_id / str(date)
+        if not day_dir.is_dir():
+            continue
+        for file in day_dir.iterdir():
+            if file.name.startswith(".azDownload") or file.suffix not in {".prq", ".h5"}:
+                continue
+            mtimes.append(file.stat().st_mtime)
+    return max(mtimes) if mtimes else None
+
+
 def get_fl_resampled_one_device(  # noqa: PLR0913
     *,
     park_id: str,
@@ -238,6 +287,7 @@ def get_fl_resampled_one_device(  # noqa: PLR0913
     min_data_count: float | None = None,
     cache_dir: Path | None = None,
     siemens_parks: set[str] | None = None,
+    refresh_cache: bool = False,
 ) -> pd.DataFrame:
     """Return resampled fastlog data for a single device over the given date range, chunked by day."""
     # chunk by day
@@ -258,6 +308,7 @@ def get_fl_resampled_one_device(  # noqa: PLR0913
             min_data_count=min_data_count,
             cache_dir=cache_dir,
             siemens_parks=siemens_parks,
+            refresh_cache=refresh_cache,
         )
         if not day_df.empty:
             day_dfs.append(day_df)

--- a/src/hot_open/sourcing_data.py
+++ b/src/hot_open/sourcing_data.py
@@ -50,7 +50,7 @@ def download_zenodo_data(
     filenames: Collection[str] | None = None,
     cache_overwrite: bool = False,
 ) -> None:
-    """Download and caches files from zenodo.org."""
+    """Download and cache files from zenodo.org."""
     output_dir = output_dir if output_dir is not None else get_data_dir()
     output_dir.mkdir(parents=True, exist_ok=True)
     metadata_fpath = output_dir / "zenodo_dataset_metadata.json"

--- a/src/hot_open/sourcing_data.py
+++ b/src/hot_open/sourcing_data.py
@@ -45,9 +45,9 @@ _HTTP_PARTIAL_CONTENT = 206
 
 def download_zenodo_data(
     record_id: str,
+    *,
     output_dir: Path | None = None,
     filenames: Collection[str] | None = None,
-    *,
     cache_overwrite: bool = False,
 ) -> None:
     """Download and caches files from zenodo.org."""

--- a/tests/test_era5_helpers.py
+++ b/tests/test_era5_helpers.py
@@ -74,9 +74,9 @@ class TestGetEra5HourlyDf:
     def test_end_date_defaults_to_today(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: dict[str, object] = {}
 
-        def fake_cache_path(*args: object) -> MagicMock:
-            # signature mirrors _era5_cache_path(lat, lon, start_date, end_date, fields)
-            captured["end_date"] = args[3]
+        def fake_cache_path(**kwargs: object) -> MagicMock:
+            # signature mirrors _era5_cache_path(*, lat, lon, start_date, end_date, fields)
+            captured["end_date"] = kwargs["end_date"]
             mock_path = MagicMock()
             mock_path.exists.return_value = True
             return mock_path

--- a/tests/test_fastlog_helpers.py
+++ b/tests/test_fastlog_helpers.py
@@ -1,9 +1,14 @@
+import os
+from pathlib import Path
+
 import pandas as pd
 import pytest
 
+import hot_open.fastlog_helpers as flh
 from hot_open.fastlog_helpers import (
     SIEMENS_PARKS,
     SIEMENS_TAGS,
+    _get_fl_resampled_one_device_one_day,
     _get_raw_df_dict,
     _get_tag_list_from_park_id,
 )
@@ -46,3 +51,95 @@ class TestSiemensParks:
             siemens_parks={"EXAMPLE"},
         )
         assert result["ActPower_Value"].empty
+
+
+PARK = "EXAMPLE"
+DEVICE = "123"
+DAY = pd.Timestamp("2024-01-01")
+DAY_END = pd.Timestamp("2024-01-02")
+
+
+def _write_source_file(*, filestore: Path, date_str: str, mtime: float) -> Path:
+    """Create a dummy raw FL file for one day and stamp its mtime."""
+    day_dir = filestore / "FL" / PARK / DEVICE / date_str
+    day_dir.mkdir(parents=True, exist_ok=True)
+    file = day_dir / f"FL{DEVICE}_Wtc_TDI_ActPower_Value_{date_str.replace('-', '_')}.prq"
+    file.write_bytes(b"x")
+    os.utime(file, (mtime, mtime))
+    return file
+
+
+def _call(filestore: Path, cache_dir: Path, *, refresh_cache: bool = False) -> pd.DataFrame:
+    return _get_fl_resampled_one_device_one_day(
+        park_id=PARK,
+        device_id=DEVICE,
+        start_dt=DAY,
+        end_dt_excl=DAY_END,
+        filestore_dir=filestore,
+        tags=["ActPower_Value"],
+        cache_dir=cache_dir,
+        siemens_parks={PARK},
+        refresh_cache=refresh_cache,
+    )
+
+
+class TestCacheSourceFreshness:
+    """Per-day cache self-invalidates when source files are newer than the cached parquet."""
+
+    @pytest.fixture
+    def spy_make(self, monkeypatch: pytest.MonkeyPatch) -> list[int]:
+        """Replace the resampler with a stub that records calls and returns a non-empty frame."""
+        calls: list[int] = []
+
+        def stub(*, start_dt: pd.Timestamp, **_: object) -> pd.DataFrame:
+            calls.append(1)
+            idx = pd.DatetimeIndex([start_dt], name="timestamp")
+            return pd.DataFrame({"ActPower_Value": [1.0]}, index=idx)
+
+        monkeypatch.setattr(flh, "make_fl_resampled_one_device", stub)
+        return calls
+
+    def test_fresh_cache_is_reused(self, tmp_path: Path, spy_make: list[int]) -> None:
+        filestore, cache = tmp_path / "fs", tmp_path / "cache"
+        _write_source_file(filestore=filestore, date_str="2024-01-01", mtime=1000.0)
+        _call(filestore, cache)  # computes + writes cache (mtime = now > 1000)
+        _call(filestore, cache)  # source unchanged -> cache hit
+        assert sum(spy_make) == 1
+
+    def test_newer_source_invalidates_cache(self, tmp_path: Path, spy_make: list[int]) -> None:
+        filestore, cache = tmp_path / "fs", tmp_path / "cache"
+        src = _write_source_file(filestore=filestore, date_str="2024-01-01", mtime=1000.0)
+        _call(filestore, cache)
+        cache_file = next((cache / "fl_resampled" / PARK / DEVICE).glob("*.parquet"))
+        os.utime(src, (cache_file.stat().st_mtime + 1000, cache_file.stat().st_mtime + 1000))
+        _call(filestore, cache)  # source now newer than cache -> recompute
+        assert sum(spy_make) == 2
+
+    def test_refresh_cache_forces_recompute(self, tmp_path: Path, spy_make: list[int]) -> None:
+        filestore, cache = tmp_path / "fs", tmp_path / "cache"
+        _write_source_file(filestore=filestore, date_str="2024-01-01", mtime=1000.0)
+        _call(filestore, cache)
+        _call(filestore, cache, refresh_cache=True)  # fresh cache, but forced
+        assert sum(spy_make) == 2
+
+    @pytest.mark.usefixtures("spy_make")
+    def test_refresh_cache_overwrites_same_file(self, tmp_path: Path) -> None:
+        filestore, cache = tmp_path / "fs", tmp_path / "cache"
+        _write_source_file(filestore=filestore, date_str="2024-01-01", mtime=1000.0)
+        _call(filestore, cache)
+        _call(filestore, cache, refresh_cache=True)
+        parquets = list((cache / "fl_resampled" / PARK / DEVICE).glob("*.parquet"))
+        assert len(parquets) == 1  # refresh_cache excluded from the cache key
+
+    def test_neighbour_day_backfill_invalidates_cache(self, tmp_path: Path, spy_make: list[int]) -> None:
+        filestore, cache = tmp_path / "fs", tmp_path / "cache"
+        _write_source_file(filestore=filestore, date_str="2024-01-01", mtime=1000.0)
+        _write_source_file(filestore=filestore, date_str="2023-12-31", mtime=1000.0)
+        _call(filestore, cache)
+        cache_file = next((cache / "fl_resampled" / PARK / DEVICE).glob("*.parquet"))
+        prev = filestore / "FL" / PARK / DEVICE / "2023-12-31"
+        newer = cache_file.stat().st_mtime + 1000
+        for f in prev.iterdir():
+            os.utime(f, (newer, newer))
+        _call(filestore, cache)  # day-1 (ffill context) backfilled -> recompute
+        assert sum(spy_make) == 2

--- a/tests/test_fastlog_helpers.py
+++ b/tests/test_fastlog_helpers.py
@@ -131,6 +131,23 @@ class TestCacheSourceFreshness:
         parquets = list((cache / "fl_resampled" / PARK / DEVICE).glob("*.parquet"))
         assert len(parquets) == 1  # refresh_cache excluded from the cache key
 
+    def test_refresh_cache_removes_stale_cache_on_empty_recompute(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        filestore, cache = tmp_path / "fs", tmp_path / "cache"
+        _write_source_file(filestore=filestore, date_str="2024-01-01", mtime=1000.0)
+        idx = pd.DatetimeIndex([pd.Timestamp("2024-01-01")], name="timestamp")
+        monkeypatch.setattr(
+            flh, "make_fl_resampled_one_device", lambda **_: pd.DataFrame({"ActPower_Value": [1.0]}, index=idx)
+        )
+        _call(filestore, cache)
+        parquet = next((cache / "fl_resampled" / PARK / DEVICE).glob("*.parquet"))
+        # Recompute now yields an empty frame (e.g. source removed/filtered): the stale parquet
+        # must not survive, or a later non-refresh run would silently reuse it.
+        monkeypatch.setattr(flh, "make_fl_resampled_one_device", lambda **_: pd.DataFrame())
+        _call(filestore, cache, refresh_cache=True)
+        assert not parquet.exists()
+
     def test_neighbour_day_backfill_invalidates_cache(self, tmp_path: Path, spy_make: list[int]) -> None:
         filestore, cache = tmp_path / "fs", tmp_path / "cache"
         _write_source_file(filestore=filestore, date_str="2024-01-01", mtime=1000.0)


### PR DESCRIPTION
Main change is to add fastlog cache refresh mechanism

I prefer kwargs to be enforced where the args meaning and order is not obvious; this normally means I allow no more than 2 args before using "*" to enforce kwargs. This PR brings the project to that style preference